### PR TITLE
ci: switch dependabot from weekly to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: cargo
     directory: /
     schedule:
-      interval: weekly
+      interval: quarterly
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
weekly crate updates is way way way more frequent than this repo needs